### PR TITLE
Fix browser opening blocking serveHTTP

### DIFF
--- a/goconvey.go
+++ b/goconvey.go
@@ -74,7 +74,7 @@ func main() {
 	server := api.NewHTTPServer(working, watcherInput, executor, longpollChan)
 	go runTestOnUpdates(watcherOutput, executor, server)
 	go watcher.Listen()
-	launchBrowser(host, port)
+	go launchBrowser(host, port)
 	serveHTTP(server)
 }
 


### PR DESCRIPTION
Running Linux the browser launch command blocks until the browser is closed. This is very confusing and unhelpful behavior.
